### PR TITLE
Make exception backtraces configurable.

### DIFF
--- a/lib/jsonapi/configuration.rb
+++ b/lib/jsonapi/configuration.rb
@@ -22,6 +22,7 @@ module JSONAPI
                 :top_level_meta_include_page_count,
                 :top_level_meta_page_count_key,
                 :allow_transactions,
+                :include_backtraces_in_errors,
                 :exception_class_whitelist,
                 :always_include_to_one_linkage_data,
                 :always_include_to_many_linkage_data,
@@ -67,6 +68,10 @@ module JSONAPI
       self.top_level_meta_page_count_key = :page_count
 
       self.use_text_errors = false
+
+      # Whether or not to include exception backtraces in JSONAPI error
+      # responses.  Defaults to `false` in production, and `true` otherwise.
+      self.include_backtraces_in_errors = !Rails.env.production?
 
       # List of classes that should not be rescued by the operations processor.
       # For example, if you use Pundit for authorization, you might
@@ -211,6 +216,8 @@ module JSONAPI
     attr_writer :top_level_meta_page_count_key
 
     attr_writer :allow_transactions
+
+    attr_writer :include_backtraces_in_errors
 
     attr_writer :exception_class_whitelist
 

--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -16,7 +16,7 @@ module JSONAPI
       end
 
       def errors
-        unless Rails.env.production?
+        if JSONAPI.configuration.include_backtraces_in_errors
           meta = Hash.new
           meta[:exception] = exception.message
           meta[:backtrace] = exception.backtrace

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -90,6 +90,25 @@ class PostsControllerTest < ActionController::TestCase
     JSONAPI.configuration.exception_class_whitelist = original_whitelist
   end
 
+  def test_exception_includes_backtrace_when_enabled
+    original_config = JSONAPI.configuration.include_backtraces_in_errors
+    $PostProcessorRaisesErrors = true
+
+    JSONAPI.configuration.include_backtraces_in_errors = true
+    assert_cacheable_get :index
+    assert_response 500
+    assert_includes @response.body, "backtrace", "expected backtrace in error body"
+
+    JSONAPI.configuration.include_backtraces_in_errors = false
+    assert_cacheable_get :index
+    assert_response 500
+    refute_includes @response.body, "backtrace", "expected backtrace in error body"
+
+  ensure
+    $PostProcessorRaisesErrors = false
+    JSONAPI.configuration.include_backtraces_in_errors = original_config
+  end
+
   def test_on_server_error_block_callback_with_exception
     original_config = JSONAPI.configuration.dup
     JSONAPI.configuration.exception_class_whitelist = []


### PR DESCRIPTION
We discovered that our staging environments were leaking internals onto the web because JSONAPI::Resources assumed that as long as the environment wasn't `production` then it could include the backtrace in the serialized error output.  This PR adds a configuration option - with the same default behaviour as previous - however it allows the behaviour to be configured if needed.